### PR TITLE
Update Lambda Runtime

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,7 @@ ansiColor('xterm') {
   def authorName  = sh(returnStdout: true, script: 'git --no-pager show --format="%an" --no-patch')
   def isMain    = env.BRANCH_NAME == "main"
   def serviceName = env.JOB_NAME.tokenize("/")[1]
+  def isRealService = serviceName != "template-serverless-service"
 
   def commitHash  = sh(returnStdout: true, script: 'git rev-parse HEAD | cut -c-7').trim()
   def imageTag    = "${env.BUILD_NUMBER}-${commitHash}"
@@ -26,12 +27,14 @@ ansiColor('xterm') {
         sh "IMAGE_TAG=${imageTag} make publish"
       }
 
-      stage("Deploy") {
-        build job: "service-deploy/pennsieve-non-prod/us-east-1/dev-vpc-use1/dev/${serviceName}",
-        parameters: [
-          string(name: 'IMAGE_TAG', value: imageTag),
-          string(name: 'TERRAFORM_ACTION', value: 'apply')
-        ]
+      if(isRealService) {
+        stage("Deploy") {
+            build job: "service-deploy/pennsieve-non-prod/us-east-1/dev-vpc-use1/dev/${serviceName}",
+            parameters: [
+                string(name: 'IMAGE_TAG', value: imageTag),
+                string(name: 'TERRAFORM_ACTION', value: 'apply')
+            ]
+        }
       }
     }
   } catch (e) {

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,8 @@
 
 LAMBDA_BUCKET ?= "pennsieve-cc-lambda-functions-use1"
 WORKING_DIR   ?= "$(shell pwd)"
-API_DIR ?= "api"
 # TODO replace template-serverless-service
 SERVICE_NAME  ?= "template-serverless-service"
-# TODO replace template_serverless_service
-SERVICE_EXEC  ?= "template_serverless_service"
-# TODO replace templateServerlessService
-SERVICE_PACK  ?= "templateServerlessService"
 PACKAGE_NAME  ?= "${SERVICE_NAME}-${IMAGE_TAG}.zip"
 
 .DEFAULT: help
@@ -51,9 +46,9 @@ package:
 	@echo "***********************"
 	@echo ""
 	cd lambda/service; \
-  		env GOOS=linux GOARCH=amd64 go build -o $(WORKING_DIR)/lambda/bin/$(SERVICE_PACK)/$(SERVICE_EXEC); \
-		cd $(WORKING_DIR)/lambda/bin/$(SERVICE_PACK)/ ; \
-			zip -r $(WORKING_DIR)/lambda/bin/$(SERVICE_PACK)/$(PACKAGE_NAME) .
+  		env GOOS=linux GOARCH=amd64 go build -tags lambda.norpc -o $(WORKING_DIR)/lambda/bin/service/bootstrap; \
+		cd $(WORKING_DIR)/lambda/bin/service/ ; \
+			zip -r $(WORKING_DIR)/lambda/bin/service/$(PACKAGE_NAME) .
 
 # Copy Service lambda to S3 location
 publish:
@@ -63,8 +58,8 @@ publish:
 	@echo "*   Publishing lambda   *"
 	@echo "*************************"
 	@echo ""
-	aws s3 cp $(WORKING_DIR)/lambda/bin/$(SERVICE_PACK)/$(PACKAGE_NAME) s3://$(LAMBDA_BUCKET)/$(SERVICE_NAME)/
-	rm -rf $(WORKING_DIR)/lambda/bin/$(SERVICE_PACK)/$(PACKAGE_NAME)
+	aws s3 cp $(WORKING_DIR)/lambda/bin/service/$(PACKAGE_NAME) s3://$(LAMBDA_BUCKET)/$(SERVICE_NAME)/
+	rm -rf $(WORKING_DIR)/lambda/bin/service/$(PACKAGE_NAME) $(WORKING_DIR)/lambda/bin/service/bootstrap
 
 # Run go mod tidy on modules
 tidy:

--- a/lambda/service/handler/handler.go
+++ b/lambda/service/handler/handler.go
@@ -2,11 +2,11 @@ package handler
 
 import (
 	"github.com/aws/aws-lambda-go/events"
+	"github.com/pennsieve/template-serverless-service/service/logging"
 	"log/slog"
-	"os"
 )
 
-var logger = slog.New(slog.NewJSONHandler(os.Stdout, nil))
+var logger = logging.Default
 
 func init() {
 	logger.Info("init()")
@@ -14,7 +14,7 @@ func init() {
 
 // TODO update Handler function name
 func TemplateServiceHandler(request events.APIGatewayV2HTTPRequest) (*events.APIGatewayV2HTTPResponse, error) {
-	logger = logger.With("requestID", request.RequestContext.RequestID)
+	logger = logger.With(slog.String("requestID", request.RequestContext.RequestID))
 
 	apiResponse, err := handleRequest()
 

--- a/lambda/service/logging/logger.go
+++ b/lambda/service/logging/logger.go
@@ -5,11 +5,11 @@ import (
 	"os"
 )
 
-// Level To change the log level at runtime, for example to DEBUG, call Level.Set(slog.LevelDebug)
-// Default value is slog.LevelInfo
+// Level is the current log level of Default. To change the level at runtime, for example to DEBUG, call Level.Set(slog.LevelDebug)
+// Defaults to slog.LevelInfo
 var Level = new(slog.LevelVar)
 
-// Default A *slog.Logger configured with a JSON handler and a level set by environment variable LOG_LEVEL
+// Default is a *slog.Logger configured with a JSON handler and a level set by environment variable LOG_LEVEL
 // If LOG_LEVEL is not set, or is set to an unknown value, level defaults to slog.LevelInfo
 var Default *slog.Logger
 

--- a/lambda/service/logging/logger.go
+++ b/lambda/service/logging/logger.go
@@ -1,0 +1,37 @@
+package logging
+
+import (
+	"log/slog"
+	"os"
+)
+
+// Level To change the log level at runtime, for example to DEBUG, call Level.Set(slog.LevelDebug)
+// Default value is slog.LevelInfo
+var Level = new(slog.LevelVar)
+
+// Default A *slog.Logger configured with a JSON handler and a level set by environment variable LOG_LEVEL
+// If LOG_LEVEL is not set, or is set to an unknown value, level defaults to slog.LevelInfo
+var Default *slog.Logger
+
+func init() {
+	configureLogging()
+}
+
+// configureLogging separated out from init() for testing with environment variables
+func configureLogging() {
+	envLogLevel := os.Getenv("LOG_LEVEL")
+	if len(envLogLevel) > 0 {
+		var level slog.Level
+		if err := level.UnmarshalText([]byte(envLogLevel)); err != nil {
+			slog.Error("error unmarshalling LOG_LEVEL value",
+				slog.String("LOG_LEVEL", envLogLevel),
+				slog.Any("error", err))
+			level = slog.LevelInfo
+		}
+		Level.Set(level)
+	}
+	h := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: Level})
+	slog.SetDefault(slog.New(h))
+	slog.Info("default log level set", slog.String("logging.Level", Level.String()))
+	Default = slog.Default()
+}

--- a/lambda/service/logging/logger_test.go
+++ b/lambda/service/logging/logger_test.go
@@ -1,0 +1,34 @@
+package logging
+
+import (
+	"github.com/stretchr/testify/require"
+	"log/slog"
+	"testing"
+)
+
+func TestLevelDefault(t *testing.T) {
+	assertLogLevelStrict(t, Default, slog.LevelInfo)
+}
+
+func TestLevelEnvVar(t *testing.T) {
+	t.Setenv("LOG_LEVEL", "DEBUG")
+	configureLogging()
+
+	assertLogLevelStrict(t, Default, slog.LevelDebug)
+
+}
+
+func TestLevelEnvVarError(t *testing.T) {
+	t.Setenv("LOG_LEVEL", "UNKNOWN_LEVEL")
+	configureLogging()
+
+	assertLogLevelStrict(t, Default, slog.LevelInfo)
+
+}
+
+func assertLogLevelStrict(t *testing.T, logger *slog.Logger, expectedLevel slog.Level) {
+	require.True(t, logger.Enabled(nil, expectedLevel))
+
+	require.True(t, logger.Enabled(nil, expectedLevel+1))
+	require.False(t, logger.Enabled(nil, expectedLevel-1))
+}

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -2,9 +2,9 @@ resource "aws_lambda_function" "service_lambda" {
   # TODO update description
   description   = "Template for building a Lambda Function which handles requests for a new serverless Service"
   function_name = "${var.environment_name}-${var.service_name}-service-lambda-${data.terraform_remote_state.region.outputs.aws_region_shortname}"
-  # TODO update handler name to match value of SERVICE_EXEC variable in Makefile
-  handler       = "template_serverless_service"
-  runtime       = "go1.x"
+  handler       = "bootstrap"
+  runtime       = "provided.al2023"
+  architectures = ["arm64"]
   role          = aws_iam_role.service_lambda_role.arn
   timeout       = 300
   memory_size   = 128


### PR DESCRIPTION
Updates Terraform Lambda resource and Makefile to replace use of [outdated Go1.x runtime](https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/) with newest version.

Also
* Adds logic to Jenkinsfile to only run Deploy when the push to main is not in this repo.
* Adds a `logging` package to configure a default JSON logger that sets its level from the environment variable `LOG_LEVEL`.