### PR TITLE
Add Context argument to example Handler

### DIFF
--- a/lambda/service/handler/handler.go
+++ b/lambda/service/handler/handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/pennsieve/template-serverless-service/service/logging"
 	"log/slog"
@@ -13,7 +14,7 @@ func init() {
 }
 
 // TODO update Handler function name
-func TemplateServiceHandler(request events.APIGatewayV2HTTPRequest) (*events.APIGatewayV2HTTPResponse, error) {
+func TemplateServiceHandler(ctx context.Context, request events.APIGatewayV2HTTPRequest) (*events.APIGatewayV2HTTPResponse, error) {
 	logger = logger.With(slog.String("requestID", request.RequestContext.RequestID))
 
 	apiResponse, err := handleRequest()

--- a/lambda/service/handler/handler_test.go
+++ b/lambda/service/handler/handler_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/stretchr/testify/assert"
 	"net/http"
@@ -8,7 +9,7 @@ import (
 )
 
 func TestHandler(t *testing.T) {
-	resp, err := TemplateServiceHandler(events.APIGatewayV2HTTPRequest{
+	resp, err := TemplateServiceHandler(context.Background(), events.APIGatewayV2HTTPRequest{
 		RequestContext: events.APIGatewayV2HTTPRequestContext{RequestID: "handler-test"}})
 	if assert.NoError(t, err) {
 		assert.Equal(t, http.StatusOK, resp.StatusCode)


### PR DESCRIPTION
Adds a `context.Context` argument to the main Lambda handler. I don't think we currently make use of this, but we should encourage its use in case we eventually need to. For example, if we want to check the Lambda deadline to see if there is enough time to finish a task before the Lambda times out. 

https://docs.aws.amazon.com/lambda/latest/dg/golang-context.html
