### PR TITLE
updates GOARCH for lambda build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ package:
 	@echo "***********************"
 	@echo ""
 	cd lambda/service; \
-  		env GOOS=linux GOARCH=amd64 go build -tags lambda.norpc -o $(WORKING_DIR)/lambda/bin/service/bootstrap; \
+  		env GOOS=linux GOARCH=arm64 go build -tags lambda.norpc -o $(WORKING_DIR)/lambda/bin/service/bootstrap; \
 		cd $(WORKING_DIR)/lambda/bin/service/ ; \
 			zip -r $(WORKING_DIR)/lambda/bin/service/$(PACKAGE_NAME) .
 


### PR DESCRIPTION
- updates GOARCH for lambda build

The current architecture results in a `runtime.InvalidEntrypoint` error