### PR TITLE
adding datadog logging to service

### DIFF
--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -1,5 +1,5 @@
 // Create log group for service lambda.
-resource "aws_cloudwatch_log_group" "service_lambda_loggroup" {
+resource "aws_cloudwatch_log_group" "service_lambda_log_group" {
   name              = "/aws/lambda/${aws_lambda_function.service_lambda.function_name}"
   retention_in_days = 30
   tags = local.common_tags
@@ -7,8 +7,8 @@ resource "aws_cloudwatch_log_group" "service_lambda_loggroup" {
 
 // Send logs from service lambda to Datadog
 resource "aws_cloudwatch_log_subscription_filter" "cloudwatch_log_group_subscription" {
-  name            = "${aws_cloudwatch_log_group.service_lambda_loggroup.name}-subscription"
-  log_group_name  = aws_cloudwatch_log_group.service_lambda_loggroup.name
+  name            = "${aws_cloudwatch_log_group.service_lambda_log_group.name}-subscription"
+  log_group_name  = aws_cloudwatch_log_group.service_lambda_log_group.name
   filter_pattern  = ""
   destination_arn = data.terraform_remote_state.region.outputs.datadog_delivery_stream_arn
   role_arn        = data.terraform_remote_state.region.outputs.cw_logs_to_datadog_logs_firehose_role_arn

--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -1,0 +1,15 @@
+// Create log group for service lambda.
+resource "aws_cloudwatch_log_group" "service_lambda_loggroup" {
+  name              = "/aws/lambda/${aws_lambda_function.service_lambda.function_name}"
+  retention_in_days = 30
+  tags = local.common_tags
+}
+
+// Send logs from service lambda to Datadog
+resource "aws_cloudwatch_log_subscription_filter" "cloudwatch_log_group_subscription" {
+  name            = "${aws_cloudwatch_log_group.service_lambda_loggroup.name}-subscription"
+  log_group_name  = aws_cloudwatch_log_group.service_lambda_loggroup.name
+  filter_pattern  = ""
+  destination_arn = data.terraform_remote_state.region.outputs.datadog_delivery_stream_arn
+  role_arn        = data.terraform_remote_state.region.outputs.cw_logs_to_datadog_logs_firehose_role_arn
+}

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -47,3 +47,8 @@ data "terraform_remote_state" "platform_infrastructure" {
     profile = var.aws_account
   }
 }
+
+# Import AWS Default SecretsManager KMS Key
+data "aws_kms_key" "ssm_kms_key" {
+  key_id = "alias/aws/secretsmanager"
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -60,7 +60,23 @@ data "aws_iam_policy_document" "service_iam_policy_document" {
   }
 
   statement {
-    sid    = "SSMPermissions"
+    # TODO update sid
+    sid    = "TemplateServiceSecretsManagerPermissions"
+    effect = "Allow"
+
+    actions = [
+      "kms:Decrypt",
+      "secretsmanager:GetSecretValue",
+    ]
+
+    resources = [
+      data.aws_kms_key.ssm_kms_key.arn,
+    ]
+  }
+
+  statement {
+    # TODO update sid
+    sid    = "TemplateServiceSSMPermissions"
     effect = "Allow"
 
     actions = [

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -59,4 +59,17 @@ data "aws_iam_policy_document" "service_iam_policy_document" {
     resources = ["*"]
   }
 
+  statement {
+    sid    = "SSMPermissions"
+    effect = "Allow"
+
+    actions = [
+      "ssm:GetParameter",
+      "ssm:GetParameters",
+      "ssm:GetParametersByPath",
+    ]
+
+    resources = ["arn:aws:ssm:${data.aws_region.current_region.name}:${data.aws_caller_identity.current.account_id}:parameter/${var.environment_name}/${var.service_name}/*"]
+  }
+
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -15,3 +15,14 @@ variable "image_tag" {}
 variable "lambda_bucket" {
   default = "pennsieve-cc-lambda-functions-use1"
 }
+
+locals {
+  domain_name = data.terraform_remote_state.account.outputs.domain_name
+  hosted_zone = data.terraform_remote_state.account.outputs.public_hosted_zone_id
+
+  common_tags = {
+    aws_account      = var.aws_account
+    aws_region       = data.aws_region.current_region.name
+    environment_name = var.environment_name
+  }
+}


### PR DESCRIPTION
* adding cloud-watch config to send logs to Datadog. 
* adding support to read service specific entries in SSM

Lambda adds cloud-watch logs without specifying directly. However, in order to send data to datadog, we need to explicitly configure the cloud-watch logs and set up the datadog subscription.